### PR TITLE
Edit some expressions to silence the warning

### DIFF
--- a/Sources/ImageScrollView.swift
+++ b/Sources/ImageScrollView.swift
@@ -87,7 +87,7 @@ open class ImageScrollView: UIScrollView {
         
         // If we're at the minimum zoom scale, preserve that by returning 0, which will be converted to the minimum
         // allowable scale when the scale is restored.
-        if scaleToRestoreAfterResize <= minimumZoomScale + CGFloat(FLT_EPSILON) {
+        if scaleToRestoreAfterResize <= minimumZoomScale + CGFloat(Float.ulpOfOne) {
             scaleToRestoreAfterResize = 0
         }
     }
@@ -130,7 +130,7 @@ open class ImageScrollView: UIScrollView {
 
     // MARK: - Display image
     
-    open func display(image image: UIImage) {
+    open func display(image: UIImage) {
 
         if let zoomView = zoomView {
             zoomView.removeFromSuperview()


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/8545248/24997095/57c4b73a-2070-11e7-9a05-443f7baedd35.png)
Edit some parts that caused the warning in Xcode 8.3, Swift 3.1. 