### PR TITLE
imageContentMode decleration updated

### DIFF
--- a/Sources/ImageScrollView.swift
+++ b/Sources/ImageScrollView.swift
@@ -24,7 +24,7 @@ open class ImageScrollView: UIScrollView {
     
     static let kZoomInFactorFromMinWhenDoubleTap: CGFloat = 2
     
-    @objc open var imageContentMode: ContentMode = .widthFill
+    @objc open var imageContentMode = ContentMode.widthFill
     @objc open var initialOffset: Offset = .begining
     
     @objc public private(set) var zoomView: UIImageView? = nil


### PR DESCRIPTION
When using with Xcode 10 and Swift 4.2 project ı was getting this error:
Error:(27, 38) 'ContentMode' is ambiguous for type lookup in this context