### PR TITLE
Make maxScaleFromMinScale open for overrides

### DIFF
--- a/Sources/ImageScrollView.swift
+++ b/Sources/ImageScrollView.swift
@@ -38,7 +38,7 @@ open class ImageScrollView: UIScrollView {
     var imageSize: CGSize = CGSize.zero
     private var pointToCenterAfterResize: CGPoint = CGPoint.zero
     private var scaleToRestoreAfterResize: CGFloat = 1.0
-    var maxScaleFromMinScale: CGFloat = 3.0
+    open var maxScaleFromMinScale: CGFloat = 3.0
     
     override open var frame: CGRect {
         willSet {


### PR DESCRIPTION
It should be possible to override the default 3.0 value to allow zooming further in on images